### PR TITLE
backends/on-machine: identify generator upfront in generate-vars

### DIFF
--- a/backends/on-machine.nix
+++ b/backends/on-machine.nix
@@ -36,6 +36,7 @@ let
       ${lib.concatMapStringsSep "\n" (gen: ''
         all_files_missing=true
         all_files_present=true
+        echo "Checking vars for ${gen.name}..."
         ${lib.concatMapStringsSep "\n" (file: ''
           OUT_FILE="$OUT_DIR"/${if file.secret then "secret" else "public"}/${file.generator}/${file.name}
           if test -e "$OUT_FILE"; then


### PR DESCRIPTION
so far, `generate-vars` would identify prompted files, yet identify the generators only after prompts.
when one reuses files names across generators, that approach leaves implicit which generator `generate-vars` is prompting file contents for.
this PR addresses this by adding an echo line before any such prompts.